### PR TITLE
Create new filter hook on `run_acf_rule_tests`

### DIFF
--- a/includes/frontend/visibility-tests/acf.php
+++ b/includes/frontend/visibility-tests/acf.php
@@ -201,6 +201,8 @@ function run_acf_rule_tests( $operator, $value, $acf_field ) {
 	} elseif ( 'empty' === $operator ) {
 		$test_result = empty( $field_value );
 	} elseif ( isset( $value ) ) {
+		// This allows developers to modify $value, including adding support for shortcode value comparisons
+		$value = apply_filters( 'bv_run_acf_rule_tests_value', $value );
 
 		// Choice values are generally arrays and need to be treated differently.
 		// Allow for type juggling here since array can include strings or numbers.


### PR DESCRIPTION
I have added a new `bv_run_acf_rule_tests_value` filter hook.

This means you can pass a shortcode into the `Value` field in the UI and run `do_shortcode` using the new filter before comparison.

This is useful when bulk importing posts using something like WP All Import, and you want to compare the value against a dynamically generated value defined in an ACF field on the current post.

```
add_filter('bv_run_acf_rule_tests_value', function($value) {
	if(str_contains($value, '[acf field=')) {
		return do_shortcode($value);
	}
	
	return $value;
});
```

<img width="292" alt="Screenshot 2023-07-03 at 20 07 24" src="https://github.com/ndiego/block-visibility/assets/443683/d21fea14-16d9-4127-8dae-793ddce5f911">
