### PR TITLE
Try dynamically moving panel to styles when there are no settings.

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -138,8 +138,7 @@ function addInspectorControls( BlockEdit ) {
 addFilter(
 	'editor.BlockEdit',
 	'block-visibility/add-inspector-controls',
-	addInspectorControls,
-	100 // We want Visibility to appear right above Advanced controls
+	addInspectorControls
 );
 
 /**

--- a/src/editor/inspector-controls/index.js
+++ b/src/editor/inspector-controls/index.js
@@ -7,7 +7,11 @@ import { assign, isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withFilters, Spinner } from '@wordpress/components';
+import { 
+	withFilters, 
+	Spinner,
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 
@@ -42,10 +46,24 @@ function VisibilityInspectorControls( props ) {
 		widgetAreaRestricted,
 	} = props;
 
+	// Determine how many other panels have been slotted into the Settings tab.
+	// see: https://github.com/WordPress/gutenberg/blob/d27c43fda419995a80b1cbdeafe2b24d9a0e2164/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js#L52
+	const settingFills = [
+		...( useSlotFills( 'InspectorControls' ) || [] ),
+		...( useSlotFills( 'InspectorControlsPosition' ) || [] ),
+	];
+	
+	console.log( settingFills );
+
+	// This is not consistent. When the page loads, the Visibility panel is not counted. 
+	// But after clicking around to various blocks, the Editor starts counting the 
+	// Visibility panel as a setting Slot. 
+	const tab = settingFills.length > 1 ? 'settings' : 'styles';
+
 	// Display a default panel with spinner when settings and variables are loading.
 	if ( settings === 'fetching' || variables === 'fetching' ) {
 		return (
-			<InspectorControls group="settings">
+			<InspectorControls group={ tab }>
 				<div className="block-visibility__controls-panel">
 					<div className="controls-panel-header">
 						<h2>{ __( 'Visibility', 'block-visibility' ) }</h2>
@@ -137,7 +155,7 @@ function VisibilityInspectorControls( props ) {
 		// of SlotFill, and is "inside" of a <SlotFillProvider> component.
 		// Therefore we can freely use SlofFill without needing to add the
 		// provider ourselves.
-		<InspectorControls group="settings">
+		<InspectorControls group={ tab }>
 			<div className="block-visibility__controls-panel">
 				<ControlsPanel
 					blockAtts={ blockAtts }


### PR DESCRIPTION
Fixes: #75  

_This currently is not working perfectly. Sometimes the Visibility panel is "counted" when checking for existing settings panels, and other times it's not._

When a block has no settings, the Visibility panel causes the Settings tab to appear. This is not ideal. The panel should behave like the Advanced panel. When there are no settings, the panel should be moved to the Styles tab. 

