### PR TITLE
Fix changelog section

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,13 +191,13 @@ The **one exception** to this is the Screen Size block controls. Visibility by s
 
 == Changelog ===
 
-= 3.1.1 = 2023-09-21 =
+= 3.1.1 - 2023-09-21 =
 
 **Fixed**
 
 * Fixed missing folders when the plugin was synced to WordPress.org.
 
-= 3.1.0 = 2023-09-21 =
+= 3.1.0 - 2023-09-21 =
 
 **Added**
 


### PR DESCRIPTION
Just a heads up that "=" as a separator does not work out.

<img width="145" alt="Bildschirmfoto 2023-09-26 um 17 05 35" src="https://github.com/ndiego/block-visibility/assets/870475/fe0d3a11-45ce-4e47-85fa-825c009b7de9">
