### PR TITLE
Fix Woo "Time Since" calculations

### DIFF
--- a/includes/frontend/visibility-tests/woocommerce/rule-tests.php
+++ b/includes/frontend/visibility-tests/woocommerce/rule-tests.php
@@ -608,7 +608,7 @@ function run_customer_time_since_order_test( $rule ) {
 	$current = current_datetime();
 
 	// Calculate the number of days between the two dates, then add 1.
-	$days_between = $current->diff( $payment_date, true )->d;
+	$days_between = $current->diff( $payment_date, true )->days;
 	$days_between = ++$days_between;
 
 	$test_result = integer_value_compare( $operator, $rule_value, $days_between );
@@ -671,7 +671,7 @@ function run_customer_time_since_product_ordered_test( $rule ) {
 			$current = current_datetime();
 
 			// Calculate the number of days between the two dates, then add 1.
-			$days_between = $current->diff( $order_date, true )->d;
+			$days_between = $current->diff( $order_date, true )->days;
 			$days_between = ++$days_between;
 		} else {
 			$days_between = 'not-ordered';
@@ -748,7 +748,7 @@ function run_customer_time_since_category_ordered_test( $rule ) {
 			$current = current_datetime();
 
 			// Calculate the number of days between the two dates, then add 1.
-			$days_between = $current->diff( $order_date, true )->d;
+			$days_between = $current->diff( $order_date, true )->days;
 			$days_between = ++$days_between;
 		} else {
 			$days_between = 'not-ordered';

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,11 @@ The **one exception** to this is the Screen Size block controls. Visibility by s
 
 == Changelog ===
 
+= 3.8.0 - 2024-12-TBD =
+
+**Fixed**
+
+* [WooCommerce] Fixed bug where the "Time Since Order" rule was no calculating the correct number of days.
 = 3.7.0 - 2024-11-08 =
 
 **Changed**


### PR DESCRIPTION
Fixes #117 

The calculation for "Time Since Order" and other "Time Since" rules did not calculate the number of days correctly, as noted in #117. 