### PR TITLE
Fix conflict with WooCommerce when Block Email Editor feature is enabled

### DIFF
--- a/includes/admin/editor.php
+++ b/includes/admin/editor.php
@@ -44,7 +44,7 @@ function enqueue_editor_scripts() {
 	// Create a global variable to indicate whether we are in full control mode
 	// or not. This is needed for the Block Visibility attribute filter since
 	// it will not allow us to fetch this data directly.
-	$is_full_control_mode = 'const blockVisibilityFullControlMode = ' . wp_json_encode( get_plugin_setting( 'enable_full_control_mode', true ) ) . ';';
+	$is_full_control_mode = 'var blockVisibilityFullControlMode = ' . wp_json_encode( get_plugin_setting( 'enable_full_control_mode', true ) ) . ';';
 
 	wp_add_inline_script(
 		'block-visibility-editor-scripts',


### PR DESCRIPTION
Fixes this error:

![Screenshot 2025-09-03 at 8 56 59 AM](https://github.com/user-attachments/assets/dbd051da-85b8-4df6-83d5-89522c60d1f3)

Here's the gist of the problem:

- WordPress Core fires the `enqueue_block_editor_assets` action.
- WooCommerce email editor fires the `enqueue_block_editor_assets` action again.
- This results in the Block Visibility plugin's `enqueue_editor_scripts` function being called and executed twice.
- The Block Visibility plugin's `enqueue_editor_scripts` function [defines a JavaScript constant](https://github.com/ndiego/block-visibility/blob/main/includes/admin/editor.php#L47).
- This results in a duplicate JS constant declaration. Since constants can't be redeclared, it causes the JS error:

![Image](https://github.com/user-attachments/assets/3fe046c9-2c92-4408-9508-b73f82441ea3)

### Backtrace
```
[29-Aug-2025 19:31:36 UTC] enqueue_editor_scripts called - Backtrace: require('wp-admin/post-new.php'),
require('wp-admin/edit-form-blocks.php'), do_action('enqueue_block_editor_assets'), WP_Hook->do_action,
WP_Hook->apply_filters, BlockVisibility\Admin\enqueue_editor_scripts
[29-Aug-2025 19:31:36 UTC] enqueue_editor_scripts called - Backtrace: require('wp-admin/post-new.php'),
require('wp-admin/edit-form-blocks.php'), require_once('wp-admin/admin-header.php'),
do_action('admin_enqueue_scripts'), WP_Hook->do_action, WP_Hook->apply_filters,
Automattic\WooCommerce\EmailEditor\Engine\Email_Editor->enqueue_admin_styles,
do_action('enqueue_block_editor_assets'), WP_Hook->do_action, WP_Hook->apply_filters,
BlockVisibility\Admin\enqueue_editor_scripts
```

To reproduce:
- Enable WooCommerce.
- In WooCommerce > Settings > Advanced > Features, enable the _Block Email Editor (Alpha)_ feature.
- Add a new post or page.
- See white screen and console error.